### PR TITLE
Made Explorer Responsive

### DIFF
--- a/block.html
+++ b/block.html
@@ -24,6 +24,7 @@
     <script src="./js/config.js"></script>
     <script src="./js/common.js"></script>
     <script src="./js/block.js"></script>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
   </head>
   <body class="has-navbar-fixed-top">
     <nav class="navbar is-fixed-top" role="navigation" aria-label="main navigation">

--- a/block.html
+++ b/block.html
@@ -72,7 +72,7 @@
         <div class="container">
           <div class="panel">
             <p class="panel-heading is-trtl-green"><i class="fas fa-dice-d6"></i>&nbsp; Block: <span id="blockHeaderHash">&nbsp;</span></p>
-            <div class="panel-block">
+            <div class="panel-block" style="overflow-x:auto;">
               <table class="table is-striped is-fullwidth">
                 <tr>
                   <th class="trtl-icon"><i class="fas fa-bars"></i></th>
@@ -133,7 +133,7 @@
           </div>
           <div class="panel">
             <p class="panel-heading is-trtl-green"><i class="fas fa-exchange-alt"></i>&nbsp; Transactions <span id="transactionCount" class="tag is-trtl-black is-rounded">0</span></p>
-            <div class="panel-block">
+            <div class="panel-block" style="overflow-x:auto;">
               <table id="transactions" class="table table-striped table-bordered is-fullwidth">
                 <thead>
                   <tr>

--- a/charts.html
+++ b/charts.html
@@ -25,6 +25,7 @@
     <script src="./js/config.js"></script>
     <script src="./js/common.js"></script>
     <script src="./js/charts.js"></script>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
   </head>
   <body class="has-navbar-fixed-top">
     <nav class="navbar is-fixed-top" role="navigation" aria-label="main navigation">

--- a/css/app.css
+++ b/css/app.css
@@ -2,7 +2,6 @@ body {
   display: flex;
   min-height: 100vh;
   flex-direction: column;
-  min-width: 1120px;
 }
 
 main {
@@ -10,10 +9,6 @@ main {
 }
 footer {
   padding: 3rem 1.5rem 1rem;
-}
-
-container {
-  min-width: 1120px;
 }
 
 .navbar-item img {

--- a/css/app.css
+++ b/css/app.css
@@ -2,14 +2,18 @@ body {
   display: flex;
   min-height: 100vh;
   flex-direction: column;
+  min-width: 1120px;
 }
 
 main {
   flex: 1;
 }
-
 footer {
   padding: 3rem 1.5rem 1rem;
+}
+
+container {
+  min-width: 1120px;
 }
 
 .navbar-item img {

--- a/index.html
+++ b/index.html
@@ -164,16 +164,16 @@
                 <i class="fas fa-link"></i>&nbsp; Recent Blocks
               </p>
               <div class="panel-block" style="overflow-x:auto;">
-                <table id="recentBlocks" class="table table-striped table-bordered is-fullwidth responsive">
+                <table id="recentBlocks" class="table table-striped table-bordered is-fullwidth responsive nowrap">
                   <thead>
                     <tr>
                       <th class="trtl-height"><i class="fas fa-bars"></i>&nbsp; Height</th>
                       <th class="trtl-size"><i class="fas fa-weight-hanging"></i>&nbsp; Size</th>
-                      <th><i class="fas fa-hashtag"></i>&nbsp; Block Hash</th>
+                      <th><i class="fas fa-hashtag"></i>&nbsp; Hash</th>
                       <th class="trtl-size"><i class="fas fa-lock"></i>&nbsp; Diff</th>
-                      <th class="trtl-txns"><i class="fas fa-file-signature"></i>&nbsp; Txns</th>
+                      <th class="trtl-txns centered"><i class="fas fa-file-signature"></i></th>
                       <th class="trtl-size"><i class="far fa-clock"></i>&nbsp; Time</th>
-                      <th class="trtl-txns"><i class="fas fa-people-carry"></i>&nbsp; Mined Via</th>
+                      <th class="trtl-txns centered"><i class="fas fa-file-signature"></i></th>
                     </tr>
                   </thead>
                 </table>

--- a/index.html
+++ b/index.html
@@ -164,14 +164,14 @@
                 <i class="fas fa-link"></i>&nbsp; Recent Blocks
               </p>
               <div class="panel-block" style="overflow-x:auto;">
-                <table id="recentBlocks" class="table table-striped table-bordered is-fullwidth responsive nowrap">
+                <table id="recentBlocks" class="table table-striped table-bordered is-fullwidth responsive">
                   <thead>
                     <tr>
                       <th class="trtl-height"><i class="fas fa-bars"></i>&nbsp; Height</th>
                       <th class="trtl-size"><i class="fas fa-weight-hanging"></i>&nbsp; Size</th>
                       <th><i class="fas fa-hashtag"></i>&nbsp; Hash</th>
                       <th class="trtl-size"><i class="fas fa-lock"></i>&nbsp; Diff</th>
-                      <th class="trtl-txns centered"><i class="fas fa-file-signature"></i></th>
+                      <th class="trtl-txns"><i class="fas fa-file-signature"></i>&nbsp; Txns</th>
                       <th class="trtl-size"><i class="far fa-clock"></i>&nbsp; Time</th>
                       <th class="trtl-txns centered"><i class="fas fa-file-signature"></i></th>
                     </tr>

--- a/index.html
+++ b/index.html
@@ -72,11 +72,11 @@
       <section class="section">
         <div class="container">
           <div class="columns">
-            <div class="column panel" style="overflow-x:auto;">
+            <div class="column panel">
               <p class="panel-heading is-trtl-green">
                 <i class="fas fa-server"></i>&nbsp; Network Stats
               </p>
-              <div class="panel-block same-height">
+              <div class="panel-block same-height" style="overflow-x:auto;">
                 <table class="table is-striped is-fullwidth chart">
                   <tr>
                     <th class="trtl-icon"><i class="fas fa-bars"></i></th>
@@ -138,11 +138,11 @@
         </div>
         <div class="container">
           <div class="columns">
-            <div class="column panel" style="overflow-x:auto;">
+            <div class="column panel">
               <p class="panel-heading is-trtl-green">
                 <i class="fas fa-exchange-alt"></i>&nbsp; Transaction Pool <span id="transactionPoolCount" class="tag is-trtl-black is-rounded">0</span>
               </p>
-              <div class="panel-block">
+              <div class="panel-block" style="overflow-x:auto;">
                 <table id="transactionPool" class="table table-striped table-bordered is-fullwidth">
                   <thead>
                     <tr>
@@ -163,7 +163,7 @@
               <p class="panel-heading is-trtl-green">
                 <i class="fas fa-link"></i>&nbsp; Recent Blocks
               </p>
-              <div class="panel-block">
+              <div class="panel-block" style="overflow-x:auto;">
                 <table id="recentBlocks" class="table table-striped table-bordered is-fullwidth responsive">
                   <thead>
                     <tr>

--- a/index.html
+++ b/index.html
@@ -25,6 +25,7 @@
     <script src="./js/config.js"></script>
     <script src="./js/common.js"></script>
     <script src="./js/main.js"></script>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
   </head>
   <body class="has-navbar-fixed-top">
     <nav class="navbar is-fixed-top" role="navigation" aria-label="main navigation">

--- a/index.html
+++ b/index.html
@@ -172,7 +172,7 @@
                       <th><i class="fas fa-hashtag"></i>&nbsp; Block Hash</th>
                       <th class="trtl-size"><i class="fas fa-lock"></i>&nbsp; Diff</th>
                       <th class="trtl-txns"><i class="fas fa-file-signature"></i>&nbsp; Txns</th>
-                      <th class="trtl-datetime"><i class="far fa-clock"></i>&nbsp; Date &amp; Time</th>
+                      <th class="trtl-size"><i class="far fa-clock"></i>&nbsp; Time</th>
                       <th class="trtl-txns"><i class="fas fa-people-carry"></i>&nbsp; Mined Via</th>
                     </tr>
                   </thead>

--- a/index.html
+++ b/index.html
@@ -70,9 +70,9 @@
     </nav>
     <main>
       <section class="section">
-        <div class="container" style="overflow-x:auto;">
+        <div class="container">
           <div class="columns">
-            <div class="column panel">
+            <div class="column panel" style="overflow-x:auto;">
               <p class="panel-heading is-trtl-green">
                 <i class="fas fa-server"></i>&nbsp; Network Stats
               </p>
@@ -138,7 +138,7 @@
         </div>
         <div class="container">
           <div class="columns">
-            <div class="column panel">
+            <div class="column panel" style="overflow-x:auto;">
               <p class="panel-heading is-trtl-green">
                 <i class="fas fa-exchange-alt"></i>&nbsp; Transaction Pool <span id="transactionPoolCount" class="tag is-trtl-black is-rounded">0</span>
               </p>
@@ -159,7 +159,7 @@
         </div>
         <div class="container">
           <div class="columns">
-            <div class="column panel">
+            <div class="column panel" style="overflow-x:auto;">
               <p class="panel-heading is-trtl-green">
                 <i class="fas fa-link"></i>&nbsp; Recent Blocks
               </p>

--- a/index.html
+++ b/index.html
@@ -70,7 +70,7 @@
     </nav>
     <main>
       <section class="section">
-        <div class="container">
+        <div class="container" style="overflow-x:auto;">
           <div class="columns">
             <div class="column panel">
               <p class="panel-heading is-trtl-green">

--- a/js/main.js
+++ b/js/main.js
@@ -100,7 +100,11 @@ $(document).ready(function () {
       targets: 6,
       render: function(data, type, row, meta) {
         if (type === 'display' && data.url) {
-          data = '<a href="' + data.url + '" target="_blank">' + data.name + '</a>'
+          const parts = data.name.split('.')
+          while (parts.length > 2) {
+            parts.shift()
+          }
+          data = '<a href="' + data.url + '" target="_blank">' + parts.join('.') + '</a>'
         } else if (type === 'display') {
           data = data.name
         }

--- a/js/main.js
+++ b/js/main.js
@@ -233,7 +233,7 @@ function updateRecentBlocks(table, height) {
           block.hash,
           numeral(block.difficulty/1000/1000/1000).format('0,0.000') + ' B',
           numeral(block.tx_count).format('0,0'),
-          (new Date(block.timestamp * 1000)).toLocaleString(),
+          (new Date(block.timestamp * 1000)).toLocaleTimeString(),
           {
             url: block.poolURL || false,
             name: block.poolName || 'Scanning...'

--- a/mixable.html
+++ b/mixable.html
@@ -73,7 +73,7 @@
         <div class="container">
           <div class="panel">
             <p class="panel-heading is-trtl-green"><i class="fas fa-mortar-pestle"></i>&nbsp; Mixable Amounts</p>
-            <div class="panel-block">
+            <div class="panel-block" style="overflow-x:auto;">
               <table id="mixableAmounts" class="table table-striped table-bordered is-fullwidth">
                 <thead>
                   <tr>

--- a/mixable.html
+++ b/mixable.html
@@ -24,6 +24,7 @@
     <script src="./js/config.js"></script>
     <script src="./js/common.js"></script>
     <script src="./js/mixable.js"></script>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
   </head>
   <body class="has-navbar-fixed-top">
     <nav class="navbar is-fixed-top" role="navigation" aria-label="main navigation">

--- a/nodes.html
+++ b/nodes.html
@@ -74,7 +74,7 @@
         <div class="container">
           <div class="panel">
             <p class="panel-heading is-trtl-green"><i class="fas fa-server"></i>&nbsp; TurtleCoin Community Nodes</span></p>
-            <div class="panel-block">
+            <div class="panel-block" style="overflow-x:auto;">
               <table id="nodes" class="table table-striped table-bordered is-fullwidth">
                 <thead>
                   <tr>

--- a/nodes.html
+++ b/nodes.html
@@ -26,6 +26,7 @@
     <script src="./js/config.js"></script>
     <script src="./js/common.js"></script>
     <script src="./js/nodes.js"></script>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
   </head>
   <body class="has-navbar-fixed-top">
     <nav class="navbar is-fixed-top" role="navigation" aria-label="main navigation">

--- a/paymentid.html
+++ b/paymentid.html
@@ -24,6 +24,7 @@
     <script src="./js/config.js"></script>
     <script src="./js/common.js"></script>
     <script src="./js/paymentid.js"></script>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
   </head>
   <body class="has-navbar-fixed-top">
     <nav class="navbar is-fixed-top" role="navigation" aria-label="main navigation">

--- a/paymentid.html
+++ b/paymentid.html
@@ -73,7 +73,7 @@
         <div class="container">
           <div class="panel">
             <p class="panel-heading is-trtl-green"><i class="fas fa-dice-d6"></i>&nbsp; Payment ID: <span id="headerPaymentId">&nbsp;</span> <span id="txnCount" class="tag is-trtl-black is-rounded">0</span></p>
-            <div class="panel-block">
+            <div class="panel-block" style="overflow-x:auto;">
               <table id="paymentIdTransactions" class="table table-striped table-bordered is-fullwidth">
                 <thead>
                   <tr>

--- a/pools.html
+++ b/pools.html
@@ -73,7 +73,7 @@
         <div class="container">
           <div class="panel">
             <p class="panel-heading is-trtl-green"><i class="fas fa-dice-d6"></i>&nbsp; TurtleCoin Mining Pools - Network Hashrate: <span id="globalHashRate">&nbsp;</span></p>
-            <div class="panel-block">
+            <div class="panel-block" style="overflow-x:auto;">
               <table id="pools" class="table table-striped table-bordered is-fullwidth">
                 <thead>
                   <tr>

--- a/pools.html
+++ b/pools.html
@@ -25,6 +25,7 @@
     <script src="./js/config.js"></script>
     <script src="./js/common.js"></script>
     <script src="./js/pools.js"></script>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
   </head>
   <body class="has-navbar-fixed-top">
     <nav class="navbar is-fixed-top" role="navigation" aria-label="main navigation">

--- a/supply.html
+++ b/supply.html
@@ -74,7 +74,7 @@
         <div class="container">
           <div class="panel">
             <p class="panel-heading is-trtl-green"><i class="fas fa-money-bill-wave-alt"></i>&nbsp; Currency Supply & Emission</p>
-            <div class="panel-block">
+            <div class="panel-block" aghbsb>
               <div id="supply" class="bigChart">Loading...</div>
             </div>
             <div></div>

--- a/supply.html
+++ b/supply.html
@@ -26,6 +26,7 @@
     <script src="./js/config.js"></script>
     <script src="./js/common.js"></script>
     <script src="./js/supply.js"></script>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
   </head>
   <body class="has-navbar-fixed-top">
     <nav class="navbar is-fixed-top" role="navigation" aria-label="main navigation">

--- a/tools.html
+++ b/tools.html
@@ -73,7 +73,7 @@
         <div class="container">
           <div class="panel">
             <p class="panel-heading is-trtl-green"><i class="fas fa-wallet"></i>&nbsp; Client Side Wallet Generator</p>
-            <div class="panel-block">
+            <div class="panel-block" style="overflow-x:auto;">
               <div class="field has-addons is-really-fullwidth">
                 <div class="control">
                   <span class="button is-trtl-black is-fixed-width-150">Random Entropy</span>
@@ -89,7 +89,7 @@
             <div class="panel-block has-text-centered has-text-weight-bold">
               Fields in red must be kept secret! Do not share with others!
             </div>
-            <div class="panel-block">
+            <div class="panel-block" style="overflow-x:auto;">
               <div class="field has-addons is-really-fullwidth">
                 <div class="control">
                   <span class="button is-trtl-red is-fixed-width-150">Wallet Seed</span>
@@ -102,7 +102,7 @@
                 </div>
               </div>
             </div>
-            <div class="panel-block">
+            <div class="panel-block" style="overflow-x:auto;">
               <div class="field has-addons is-really-fullwidth">
                 <div class="control">
                   <span class="button is-trtl-red is-fixed-width-150">Mnemonic Words</span>
@@ -115,7 +115,7 @@
                 </div>
               </div>
             </div>
-            <div class="panel-block">
+            <div class="panel-block" style="overflow-x:auto;">
               <div class="field has-addons is-really-fullwidth">
                 <div class="control">
                   <span class="button is-trtl-red is-fixed-width-150">Private Spend Key</span>
@@ -125,7 +125,7 @@
                 </div>
               </div>
             </div>
-            <div class="panel-block">
+            <div class="panel-block" style="overflow-x:auto;">
               <div class="field has-addons is-really-fullwidth">
                 <div class="control">
                   <span class="button is-trtl-black is-fixed-width-150">Public Spend Key</span>
@@ -135,7 +135,7 @@
                 </div>
               </div>
             </div>
-            <div class="panel-block">
+            <div class="panel-block" style="overflow-x:auto;">
               <div class="field has-addons is-really-fullwidth">
                 <div class="control">
                   <span class="button is-trtl-red is-fixed-width-150">Private View Key</span>
@@ -145,7 +145,7 @@
                 </div>
               </div>
             </div>
-            <div class="panel-block">
+            <div class="panel-block" style="overflow-x:auto;">
               <div class="field has-addons is-really-fullwidth">
                 <div class="control">
                   <span class="button is-trtl-black is-fixed-width-150">Public View Key</span>
@@ -155,7 +155,7 @@
                 </div>
               </div>
             </div>
-            <div class="panel-block">
+            <div class="panel-block" style="overflow-x:auto;">
               <div class="field has-addons is-really-fullwidth">
                 <div class="control">
                   <a class="button is-trtl-secondary-green is-fixed-width-150">Wallet Address</a>
@@ -168,7 +168,7 @@
           </div>
           <div class="panel">
             <p class="panel-heading is-trtl-green"><i class="fas fa-user-secret"></i>&nbsp; Address Encoder / Decoder</p>
-            <div class="panel-block">
+            <div class="panel-block" style="overflow-x:auto;">
               <div class="field has-addons is-really-fullwidth">
                 <div class="control is-really-fullwidth">
                   <input class="input is-fullwidth" type="text" placeholder="Wallet Address" id="walletAddress">
@@ -178,7 +178,7 @@
                 </div>
               </div>
             </div>
-            <div class="panel-block">
+            <div class="panel-block" style="overflow-x:auto;">
               <div class="field has-addons is-really-fullwidth">
                 <div class="control">
                   <span class="button is-trtl-black is-fixed-width-150">Public Spend Key</span>
@@ -188,7 +188,7 @@
                 </div>
               </div>
             </div>
-            <div class="panel-block">
+            <div class="panel-block" style="overflow-x:auto;">
               <div class="field has-addons is-really-fullwidth">
                 <div class="control">
                   <span class="button is-trtl-black is-fixed-width-150">Public View Key</span>
@@ -198,7 +198,7 @@
                 </div>
               </div>
             </div>
-            <div class="panel-block">
+            <div class="panel-block" style="overflow-x:auto;">
               <div class="field has-addons is-really-fullwidth">
                 <div class="control">
                   <span class="button is-trtl-black is-fixed-width-150">Payment ID</span>
@@ -211,7 +211,7 @@
                 </div>
               </div>
             </div>
-            <div class="panel-block">
+            <div class="panel-block" style="overflow-x:auto;">
               <div class="field has-addons is-really-fullwidth">
                 <div class="control">
                   <a class="button is-trtl-secondary-green is-fixed-width-150">Encoded Address</a>

--- a/tools.html
+++ b/tools.html
@@ -25,6 +25,7 @@
     <script src="./js/common.js"></script>
     <script src="./js/TurtleCoinUtils.js"></script>
     <script src="./js/tools.js"></script>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
   </head>
   <body class="has-navbar-fixed-top">
     <nav class="navbar is-fixed-top" role="navigation" aria-label="main navigation">

--- a/transaction.html
+++ b/transaction.html
@@ -25,6 +25,7 @@
     <script src="./js/common.js"></script>
     <script src="./js/TurtleCoinUtils.js"></script>
     <script src="./js/transaction.js"></script>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
   </head>
   <body class="has-navbar-fixed-top">
     <nav class="navbar is-fixed-top" role="navigation" aria-label="main navigation">

--- a/transaction.html
+++ b/transaction.html
@@ -73,7 +73,7 @@
         <div class="container">
           <div class="panel">
             <p class="panel-heading is-trtl-green"><i class="fas fa-dice-d6"></i>&nbsp; Transaction: <span id="transactionHeaderHash">&nbsp;</span></p>
-            <div class="panel-block">
+            <div class="panel-block" style="overflow-x:auto;">
               <table class="table is-striped is-fullwidth">
                 <tr>
                   <th class="trtl-icon"><i class="fas fa-clock"></i></th>
@@ -130,7 +130,7 @@
           </div>
           <div class="panel">
             <p class="panel-heading is-trtl-green"><i class="fas fa-sign-in-alt"></i>&nbsp; Inputs <span id="inputCount" class="tag is-trtl-black is-rounded">0</span></p>
-            <div class="panel-block">
+            <div class="panel-block" style="overflow-x:auto;">
               <table id="inputs" class="table table-striped table-bordered is-fullwidth">
                 <thead>
                   <tr>
@@ -144,7 +144,7 @@
           </div>
           <div class="panel">
             <p class="panel-heading is-trtl-green"><i class="fas fa-sign-out-alt"></i>&nbsp; Outputs <span id="outputCount" class="tag is-trtl-black is-rounded">0</span></p>
-            <div class="panel-block">
+            <div class="panel-block" style="overflow-x:auto;">
               <table id="outputs" class="table table-striped table-bordered is-fullwidth">
                 <thead>
                   <tr>
@@ -158,7 +158,7 @@
           </div>
           <div class="panel">
             <p class="panel-heading is-trtl-green"><i class="fas fa-user-check"></i>&nbsp; Check Transaction<span id="ourAmount">&nbsp;</span></p>
-            <div class="panel-block">
+            <div class="panel-block" style="overflow-x:auto;">
               <table class="table is-fullwidth">
                 <td><input id="key" type="text" class="input" size="70" maxlength="64" placeholder="64 Character Private View or Transaction Key" /></td>
                 <td><input id="recipientAddress" type="text" class="input" size="70" placeholder="Recipient Address" /></td>


### PR DESCRIPTION
Based on my previous experience in using the explorer from mobile, I decided to bring in a updates in order to make the explorer compatible. Here's a list of changes -

Made all the tables horizontally scrollable.
The graphs have been adjusted to fit in the screen without loss of quality.
Here's an example of how the explorer looks right now - https://sohamb03.me/blockchain-explorer 

*The previous one had an issue which has been fixed and for those of you who had visited the demo explorer during the previous PR, please clear your cache and then visit it again. I've had issues viewing the latest one and that's why.*